### PR TITLE
Trim trailing whitespace

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openbgpd (6.9p0-2) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 28 Aug 2021 09:14:08 -0000
+
 openbgpd (6.9p0-1) unstable; urgency=low
 
   * Import OpenBGPD 6.9
@@ -12,7 +18,7 @@ openbgpd (6.8p1-3) unstable; urgency=medium
 
 openbgpd (6.8p1-2) unstable; urgency=low
 
-  * Mark conflict with quagga-bgpd (Closes: #986788) 
+  * Mark conflict with quagga-bgpd (Closes: #986788)
 
  -- Job Snijders <job@openbsd.org>  Mon, 12 Apr 2021 23:38:45 +0200
 
@@ -21,4 +27,3 @@ openbgpd (6.8p1-1) unstable; urgency=low
   * Initial release (Closes: #984811)
 
  -- Job Snijders <job@openbsd.org>  Tue, 09 Mar 2021 15:37:33 +0100
-


### PR DESCRIPTION

Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/openbgpd/cd6e9196-5f58-4e14-b632-ab70006bbe0c.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/cd6e9196-5f58-4e14-b632-ab70006bbe0c/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/cd6e9196-5f58-4e14-b632-ab70006bbe0c/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/cd6e9196-5f58-4e14-b632-ab70006bbe0c/diffoscope)).
