### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -57,4 +57,3 @@ openbgpd (6.8p1-1) unstable; urgency=low
   * Initial release (Closes: #984811)
 
  -- Job Snijders <job@openbsd.org>  Tue, 09 Mar 2021 15:37:33 +0100
-

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Job Snijders <job@openbsd.org>
 Uploaders: John Goerzen <jgoerzen@complete.org>
 Build-Depends: debhelper-compat (= 13), libevent-dev
-Standards-Version: 4.5.1
+Standards-Version: 4.6.1
 Homepage: https://www.openbgpd.org/
 Vcs-Browser: https://github.com/job/debian-openbgpd
 Vcs-Git: https://github.com/job/debian-openbgpd.git


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))

* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/openbgpd/ee9a9c79-60e6-4eea-a8b7-8333a9075fd5.
